### PR TITLE
Switch to smaller, pre-built gdal base image

### DIFF
--- a/pipeline.Dockerfile
+++ b/pipeline.Dockerfile
@@ -1,25 +1,30 @@
 # syntax = docker/dockerfile:1
-FROM python:3.11
+# Note: Image version should match GDAL version in requirements-pipeline.txt
+# for current versions, see https://github.com/OSGeo/gdal/pkgs/container/gdal,
+# sha256:c7d5058385 corresponds to 3.8.1
+FROM ghcr.io/osgeo/gdal:ubuntu-small-latest@sha256:c7d5058385b0726379f241ebd0fa4754bba789dd6c9d0ae34b1e53bb373a1647
 
-LABEL org.opencontainers.image.title="data pipeline API"
+LABEL org.opencontainers.image.title="MobiData-BW Data Pipeline API"
 LABEL org.opencontainers.image.authors="Holger Bruch <hb@mfdz.de>, MobiData-BW IPL contributors <mobidata-bw@nvbw.de>"
 LABEL org.opencontainers.image.documentation="https://github.com/mobidata-bw/ipl-dagster-pipeline"
 LABEL org.opencontainers.image.source="https://github.com/mobidata-bw/ipl-dagster-pipeline"
 LABEL org.opencontainers.image.licenses="(EUPL-1.2)"
 
+RUN apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip \
+    && rm -rf /var/lib/apt/lists/*;
+
 WORKDIR /opt/dagster/app
 
-RUN apt update && apt install -y \
-	libgdal-dev \
-	&& rm -rf /var/lib/apt/lists/*
 
 # Checkout and install dagster libraries needed to run the gRPC server
 # exposing your repository to dagit and dagster-daemon, and to load the DagsterInstance
 COPY requirements-pipeline.txt /opt/dagster/app
 
 # Install requirements
+# pip complains about Fionas version, use legacy-resolver to work around (see https://stackoverflow.com/questions/67074684/pip-has-problems-with-metadata)
 RUN --mount=type=cache,target=/root/.cache/pip \
-	pip install -r requirements-pipeline.txt
+	pip install --use-deprecated=legacy-resolver -r requirements-pipeline.txt
 
 # Add repository code
 COPY pipeline/ /opt/dagster/app/pipeline/

--- a/requirements-pipeline.txt
+++ b/requirements-pipeline.txt
@@ -2,4 +2,4 @@ dagster==1.5.7
 dagster-postgres==0.21.7
 geopandas==0.14.1
 GeoAlchemy2==0.14.2
-GDAL==3.7.2
+GDAL~=3.8.1


### PR DESCRIPTION
This PR switches to the official [GDAL pre-built image](https://github.com/OSGeo/gdal/pkgs/container/gdal) to avoid the need to compile it in the dagster-pipeline image. It is available both for `linux/arm64` and `linux/amd64`.

Current python version of the `ubuntu-small-gdal:3.7.2` image is `3.10.12`.

