### PR TITLE
Bump dependency versions

### DIFF
--- a/requirements-dagster.txt
+++ b/requirements-dagster.txt
@@ -1,5 +1,5 @@
-dagster==1.5.7
-dagster-graphql==1.5.7
-dagster-webserver==1.5.7
-dagster-postgres==0.21.7
-dagster-docker==0.21.7
+dagster==1.5.10
+dagster-graphql==1.5.10
+dagster-webserver==1.5.10
+dagster-postgres==0.21.10
+dagster-docker==0.21.10

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 types-requests==2.31.0.10
 types-urllib3==1.26.25.14
-types-psycopg2==2.9.21.17
+types-psycopg2==2.9.21.19
 pandas-stubs==2.1.1.230928
 types-SQLAlchemy==1.4.53.38
 

--- a/requirements-pipeline.txt
+++ b/requirements-pipeline.txt
@@ -1,5 +1,5 @@
-dagster==1.5.7
-dagster-postgres==0.21.7
+dagster==1.5.10
+dagster-postgres==0.21.10
 geopandas==0.14.1
 GeoAlchemy2==0.14.2
 GDAL~=3.8.1


### PR DESCRIPTION
This PR bumps a couple of dependency versions, i.e. dagster => 1.5.10