### PR TITLE
bring back python image as gdal image has broken python env

### DIFF
--- a/pipeline.Dockerfile
+++ b/pipeline.Dockerfile
@@ -1,8 +1,5 @@
 # syntax = docker/dockerfile:1
-# Note: Image version should match GDAL version in requirements-pipeline.txt
-# for current versions, see https://github.com/OSGeo/gdal/pkgs/container/gdal,
-# sha256:c7d5058385 corresponds to 3.8.1
-FROM ghcr.io/osgeo/gdal:ubuntu-small-latest@sha256:c7d5058385b0726379f241ebd0fa4754bba789dd6c9d0ae34b1e53bb373a1647
+FROM python:3.11-slim
 
 LABEL org.opencontainers.image.title="MobiData-BW Data Pipeline API"
 LABEL org.opencontainers.image.authors="Holger Bruch <hb@mfdz.de>, MobiData-BW IPL contributors <mobidata-bw@nvbw.de>"
@@ -10,21 +7,20 @@ LABEL org.opencontainers.image.documentation="https://github.com/mobidata-bw/ipl
 LABEL org.opencontainers.image.source="https://github.com/mobidata-bw/ipl-dagster-pipeline"
 LABEL org.opencontainers.image.licenses="(EUPL-1.2)"
 
-RUN apt-get update -y \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip \
-    && rm -rf /var/lib/apt/lists/*;
-
 WORKDIR /opt/dagster/app
 
+RUN apt update && apt install -y \
+	build-essential \
+	libgdal-dev \
+	&& rm -rf /var/lib/apt/lists/*
 
 # Checkout and install dagster libraries needed to run the gRPC server
 # exposing your repository to dagit and dagster-daemon, and to load the DagsterInstance
 COPY requirements-pipeline.txt /opt/dagster/app
 
 # Install requirements
-# pip complains about Fionas version, use legacy-resolver to work around (see https://stackoverflow.com/questions/67074684/pip-has-problems-with-metadata)
 RUN --mount=type=cache,target=/root/.cache/pip \
-	pip install --use-deprecated=legacy-resolver -r requirements-pipeline.txt
+	pip install -r requirements-pipeline.txt
 
 # Add repository code
 COPY pipeline/ /opt/dagster/app/pipeline/

--- a/requirements-pipeline.txt
+++ b/requirements-pipeline.txt
@@ -3,4 +3,5 @@ dagster-postgres==0.21.10
 dagster-docker==0.21.10
 geopandas==0.14.1
 GeoAlchemy2==0.14.2
-GDAL~=3.8.1
+# Because a specific version of the PyPi GDAL package depends on specific OS library versions, and because Ubuntu (LTS) currently only provides *older* versions of them, we ping GDAL to v3.6 here.
+GDAL~=3.6.4


### PR DESCRIPTION
It turns out that the GDAL image installes python packages from apt sources, which ends up in an instable python environment due mixed up python package versions and libraries. This MR brings back the old python image with a proper python environment. Only disadvantage is that we are stuck on GDAL from 22.04 = 3.6.4 because GDAL needs its C library, and this is fixed by Ubuntu 22.04 packages. Every other python package, especially numpy which was broken due GDAL image design decisions, will work again.