### PR TITLE
Add column capacity to sharing_stations asset

### DIFF
--- a/pipeline/sources/lamassu.py
+++ b/pipeline/sources/lamassu.py
@@ -16,6 +16,7 @@ STATION_COLUMNS = {
     'feed_id': pd.StringDtype(),
     'station_id': pd.StringDtype(),
     'name': pd.StringDtype(),
+    'capacity': pd.Int32Dtype(),
     'rental_uris_android': pd.StringDtype(),
     'rental_uris_ios': pd.StringDtype(),
     'rental_uris_web': pd.StringDtype(),


### PR DESCRIPTION
This PR adds GBFS' `station_information.capacity` property as a new column to the static `sharing_stations` asset.