### PR TITLE
Fix sharing column types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+The changelog lists most feature changes between each release. 
+
+
+## 2024-05-17
+- change: `sharing_station_status` now reports vehicle availability for the feed's predominant `form_factor`, even for station, which don't have `vehicle_types_available` explicitly stated. Note: this requires, that all `vehicle_types` in `vehicle_types.json` declare the same `form_factor`. 
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 The changelog lists most feature changes between each release. 
 
-
-## 2024-05-17
+## 2024-06-26
+- change: `sharing_station.capacity` is changed to an integer field, `vehicle.max_range_meters` and `vehicle.current_range_meters`, according to the [GBFS spec](https://github.com/MobilityData/gbfs/blob/cd75662c25180f68f76237f88a861d82e940cf3b/gbfs.md?plain=1#L1044), to float.
 - change: `sharing_station_status` now reports vehicle availability for the feed's predominant `form_factor`, even for station, which don't have `vehicle_types_available` explicitly stated. Note: this requires, that all `vehicle_types` in `vehicle_types.json` declare the same `form_factor`. 
-

--- a/pipeline/sources/lamassu.py
+++ b/pipeline/sources/lamassu.py
@@ -101,7 +101,13 @@ class Lamassu:
             return 'num_scooters_standing_available'
         return 'num_' + form_factor + 's_available'
 
-    def _get_default_vehicle_type(self, vehicle_types_df):
+    def _get_default_vehicle_type(self, vehicle_types_df: pd.DataFrame) -> list[dict]:
+        """
+        In case all given vehicle types are of the same form factor,
+        this function will return a minimal available_vehicles array including
+        an arbitrary vehicle_type (which will by it's form factor define the station's
+        form_factor).
+        """
         vt_grouped_by_form_factor = vehicle_types_df.groupby('form_factor')
         if len(vt_grouped_by_form_factor) == 1:
             # as all vehicle_types have the same form_factor,
@@ -230,7 +236,7 @@ class Lamassu:
             for record in data:
                 # if record has no record_path property, or it's an empty collection, we replace by the default
                 if record_path not in record or (
-                    hasattr(record[record_path], '__len__') and len(record[record_path]) == 0
+                    isinstance(record[record_path], list) and len(record[record_path]) == 0
                 ):
                     record[record_path] = default_record_path
         return pd.json_normalize(data, record_path, meta, sep='_')


### PR DESCRIPTION
This PR fixes column types of sharing tables `sharing_station` and `vehicles`:

* `capacity` is now explicitly coerced to `integer`, as before missing values resulted in type `float`
* for `current_range_meters` and `max_range_meters`, the column type is changed to `float`, as stated in the GBFS spec, see [vehicles[].current_range_meters](https://github.com/MobilityData/gbfs/blob/cd75662c25180f68f76237f88a861d82e940cf3b/gbfs.md?plain=1#L1044) and [vehicle_types[].max_range_meters](https://github.com/MobilityData/gbfs/blob/cd75662c25180f68f76237f88a861d82e940cf3b/gbfs.md?plain=1#L618)

After this PR has been merged, https://github.com/mobidata-bw/ipl-orchestration/pull/154 can be addressed.