### PR TITLE
Bump dagster to 1.7.12 / dagster-docker to 0.23.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog lists most feature changes between each release. 
 
+## Unreleased
+- change: bump dagster to v1.7.12 and dagster-docker to v0.23.12
+
 ## 2024-06-26
 - change: `sharing_station.capacity` is changed to an integer field, `vehicle.max_range_meters` and `vehicle.current_range_meters`, according to the [GBFS spec](https://github.com/MobilityData/gbfs/blob/cd75662c25180f68f76237f88a861d82e940cf3b/gbfs.md?plain=1#L1044), to float.
 - change: `sharing_station_status` now reports vehicle availability for the feed's predominant `form_factor`, even for station, which don't have `vehicle_types_available` explicitly stated. Note: this requires, that all `vehicle_types` in `vehicle_types.json` declare the same `form_factor`. 

--- a/requirements-dagster.txt
+++ b/requirements-dagster.txt
@@ -1,5 +1,5 @@
-dagster==1.6.9
-dagster-graphql==1.6.9
-dagster-webserver==1.6.9
-dagster-postgres==0.22.9
-dagster-docker==0.22.9
+dagster==1.7.12
+dagster-graphql==1.7.12
+dagster-webserver==1.7.12
+dagster-postgres==0.23.12
+dagster-docker==0.23.12

--- a/requirements-pipeline.txt
+++ b/requirements-pipeline.txt
@@ -1,6 +1,6 @@
-dagster==1.6.9
-dagster-postgres==0.22.9
-dagster-docker==0.22.9
+dagster==1.7.12
+dagster-postgres==0.23.12
+dagster-docker==0.23.12
 geopandas==0.14.3
 GeoAlchemy2==0.14.4
 # Because a specific version of the PyPi GDAL package depends on specific OS library versions, and because Ubuntu (LTS) currently only provides *older* versions of them, we ping GDAL to v3.6 here.


### PR DESCRIPTION
This PR bumps dagster to 1.7.12 / dagster-docker to 0.23.12.