### PR TITLE
Create primary key for new tables

### DIFF
--- a/pipeline/resources/postgis_geopandas_io_manager.py
+++ b/pipeline/resources/postgis_geopandas_io_manager.py
@@ -232,7 +232,10 @@ class PostGISGeoPandasIOManager(PostgreSQLPandasIOManager):  # type: ignore
                         # All data can be replaced (i.e. truncated before insertion).
                         # geopandas will take care of this.
                         self._truncate_table(schema, table, con)
-
+                # while writing standard pandas.DataFrames to sql tables is database agnostic and performed
+                # internally via SQLAlchemy, writing a GeoDataFrame requires explicitly using to_postgis. See
+                # https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_sql.html and
+                # https://geopandas.org/en/stable/docs/reference/api/geopandas.GeoDataFrame.to_postgis.html
                 obj.to_postgis(
                     con=con, name=table, index=True, schema=schema, if_exists='append', chunksize=self.chunksize
                 )


### PR DESCRIPTION
This PR
* will create primary keys for newly created tables (`GeoDataFrame.to_postgis(...index=True)` does not create them)
* will avoid recreating existing tables ((geo)pandas to_sql/to_postgis `replace` action drops the table and recreates it (see [to_postgis](https://geopandas.org/en/stable/docs/reference/api/geopandas.GeoDataFrame.to_postgis.html)). Helpful would be, if replace would implement truncate/insert and a not-yet-existing option `recreate` would drop and create the table...)
