### PR TITLE
New asset: download webcam images

### DIFF
--- a/pipeline.Dockerfile
+++ b/pipeline.Dockerfile
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 # Add repository code
 COPY pipeline/ /opt/dagster/app/pipeline/
-COPY scripts/ /opt/dagster/app/scripts
+COPY scripts/ /opt/dagster/app/scripts/
 
 # Run dagster gRPC server on port 4000
 

--- a/pipeline.Dockerfile
+++ b/pipeline.Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /opt/dagster/app
 RUN apt update && apt install -y \
 	build-essential \
 	libgdal-dev \
+	lftp \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Checkout and install dagster libraries needed to run the gRPC server
@@ -24,6 +25,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 # Add repository code
 COPY pipeline/ /opt/dagster/app/pipeline/
+COPY scripts/ /opt/dagster/app/scripts
 
 # Run dagster gRPC server on port 4000
 

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -2,6 +2,7 @@ from dagster import (
     DefaultScheduleStatus,
     Definitions,
     EnvVar,
+    PipesSubprocessClient,
     ScheduleDefinition,
     define_asset_job,
     load_assets_from_modules,
@@ -25,6 +26,7 @@ defs = Definitions(
             password=EnvVar('IPL_POSTGRES_PASSWORD'),
             database=EnvVar('IPL_POSTGRES_DB'),
         ),
+        'pipes_subprocess_client': PipesSubprocessClient(),
         'json_webasset_io_manager': JsonWebAssetIOManager(
             destination_directory=EnvVar('WWW_ROOT_DIR'),
         ),

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -12,7 +12,13 @@ from .assets import gtfs, radvis, sharing, traffic_incidents, webcams
 from .resources import JsonWebAssetIOManager, LamassuResource, PostGISGeoPandasIOManager
 from .resources.gdal import Ogr2OgrResource
 
-assets = load_assets_from_modules([sharing, radvis, gtfs, traffic_incidents, webcams])
+assets = load_assets_from_modules([
+    sharing,
+    radvis,
+    gtfs,
+    traffic_incidents,
+    webcams,
+])
 
 defs = Definitions(
     assets=assets,

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -12,13 +12,15 @@ from .assets import gtfs, radvis, sharing, traffic_incidents, webcams
 from .resources import JsonWebAssetIOManager, LamassuResource, PostGISGeoPandasIOManager
 from .resources.gdal import Ogr2OgrResource
 
-assets = load_assets_from_modules([
-    sharing,
-    radvis,
-    gtfs,
-    traffic_incidents,
-    webcams,
-])
+assets = load_assets_from_modules(
+    [
+        sharing,
+        radvis,
+        gtfs,
+        traffic_incidents,
+        webcams,
+    ]
+)
 
 defs = Definitions(
     assets=assets,

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -7,11 +7,11 @@ from dagster import (
     load_assets_from_modules,
 )
 
-from .assets import gtfs, radvis, sharing, traffic_incidents
+from .assets import gtfs, radvis, sharing, traffic_incidents, webcams
 from .resources import JsonWebAssetIOManager, LamassuResource, PostGISGeoPandasIOManager
 from .resources.gdal import Ogr2OgrResource
 
-assets = load_assets_from_modules([sharing, radvis, gtfs, traffic_incidents])
+assets = load_assets_from_modules([sharing, radvis, gtfs, traffic_incidents, webcams])
 
 defs = Definitions(
     assets=assets,

--- a/pipeline/assets/webcams.py
+++ b/pipeline/assets/webcams.py
@@ -1,0 +1,32 @@
+import os
+import random
+import warnings
+
+from dagster import (
+    AssetExecutionContext,
+    AutoMaterializePolicy,
+    ExperimentalWarning,
+    FreshnessPolicy,
+    asset,
+)
+from dagster_shell import execute_shell_command
+
+SCRIPT_DIR = os.getenv('SCRIPT_DIR', './scripts/')
+
+
+@asset(
+    compute_kind='shell',
+    group_name='webcams',
+    freshness_policy=FreshnessPolicy(maximum_lag_minutes=2, cron_schedule='* * * * *'),
+    auto_materialize_policy=AutoMaterializePolicy.eager(),
+)
+def webcam_images(context: AssetExecutionContext) -> None:
+    """
+    Downloads webcam images via lftp.
+    """
+    (logs, exit_code) = execute_shell_command(
+        'bash download_webcams.sh', cwd=SCRIPT_DIR, output_logging='STREAM', log=context.log
+    )
+
+    if exit_code != 0:
+        raise RuntimeError(f'Downloading webcam images failed with error code {exit_code}')

--- a/pipeline/assets/webcams.py
+++ b/pipeline/assets/webcams.py
@@ -1,14 +1,12 @@
 import os
 import random
 import warnings
-from typing import Sequence
 
 from dagster import (
     AssetExecutionContext,
     AutoMaterializePolicy,
     ExperimentalWarning,
     FreshnessPolicy,
-    PipesExecutionResult,
     PipesSubprocessClient,
     asset,
 )
@@ -22,9 +20,8 @@ SCRIPT_DIR = os.getenv('SCRIPT_DIR', './scripts/')
     freshness_policy=FreshnessPolicy(maximum_lag_minutes=2, cron_schedule='* * * * *'),
     auto_materialize_policy=AutoMaterializePolicy.eager(),
 )
-def webcam_images(
-    context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient
-) -> Sequence['PipesExecutionResult']:
+# explicitly no typing '-> Sequence[PipesExecutionResult]' due to https://github.com/dagster-io/dagster/issues/25490
+def webcam_images(context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient):
     """
     Downloads webcam images via lftp.
     """

--- a/pipeline/assets/webcams.py
+++ b/pipeline/assets/webcams.py
@@ -14,6 +14,17 @@ from dagster import (
 SCRIPT_DIR = os.getenv('SCRIPT_DIR', './scripts/')
 
 
+def _env_vars_map(env_vars: list[str]) -> dict[str, str]:
+    env = {}
+    for env_var in env_vars:
+        value = os.getenv(env_var)
+        if value is None:
+            raise ValueError(f'Environment variable {env_var} is required but not undefined')
+        env[env_var] = value
+
+    return env
+
+
 @asset(
     compute_kind='shell',
     group_name='webcams',
@@ -25,7 +36,7 @@ def webcam_images(context: AssetExecutionContext, pipes_subprocess_client: Pipes
     """
     Downloads webcam images via lftp.
     """
-
+    env = _env_vars_map(['IPL_WEBCAM_USER', 'IPL_WEBCAM_PASSWORD', 'IPL_WEBCAM_SERVER', 'WEBCAM_KEEP_DAYS'])
     return pipes_subprocess_client.run(
-        command=['bash', 'download_webcams.sh'], context=context, cwd=SCRIPT_DIR
+        command=['bash', 'download_webcams.sh'], context=context, cwd=SCRIPT_DIR, env=env
     ).get_results()

--- a/requirements-dagster.txt
+++ b/requirements-dagster.txt
@@ -1,5 +1,5 @@
-dagster==1.7.12
-dagster-graphql==1.7.12
-dagster-webserver==1.7.12
-dagster-postgres==0.23.12
-dagster-docker==0.23.12
+dagster==1.8.12
+dagster-graphql==1.8.12
+dagster-webserver==1.8.12
+dagster-postgres==0.24.12
+dagster-docker==0.24.12

--- a/requirements-dagster.txt
+++ b/requirements-dagster.txt
@@ -3,4 +3,3 @@ dagster-graphql==1.7.12
 dagster-webserver==1.7.12
 dagster-postgres==0.23.12
 dagster-docker==0.23.12
-dagster-shell==0.23.12

--- a/requirements-dagster.txt
+++ b/requirements-dagster.txt
@@ -3,3 +3,4 @@ dagster-graphql==1.7.12
 dagster-webserver==1.7.12
 dagster-postgres==0.23.12
 dagster-docker==0.23.12
+dagster-shell==0.23.12

--- a/requirements-pipeline.txt
+++ b/requirements-pipeline.txt
@@ -1,6 +1,7 @@
 dagster==1.7.12
 dagster-postgres==0.23.12
 dagster-docker==0.23.12
+dagster-shell==0.23.12
 geopandas==0.14.3
 GeoAlchemy2==0.14.4
 # Because a specific version of the PyPi GDAL package depends on specific OS library versions, and because Ubuntu (LTS) currently only provides *older* versions of them, we ping GDAL to v3.6 here.

--- a/requirements-pipeline.txt
+++ b/requirements-pipeline.txt
@@ -1,7 +1,6 @@
 dagster==1.7.12
 dagster-postgres==0.23.12
 dagster-docker==0.23.12
-dagster-shell==0.23.12
 geopandas==0.14.3
 GeoAlchemy2==0.14.4
 # Because a specific version of the PyPi GDAL package depends on specific OS library versions, and because Ubuntu (LTS) currently only provides *older* versions of them, we ping GDAL to v3.6 here.

--- a/requirements-pipeline.txt
+++ b/requirements-pipeline.txt
@@ -1,6 +1,6 @@
-dagster==1.7.12
-dagster-postgres==0.23.12
-dagster-docker==0.23.12
+dagster==1.8.12
+dagster-postgres==0.24.12
+dagster-docker==0.24.12
 geopandas==0.14.3
 GeoAlchemy2==0.14.4
 # Because a specific version of the PyPi GDAL package depends on specific OS library versions, and because Ubuntu (LTS) currently only provides *older* versions of them, we ping GDAL to v3.6 here.

--- a/scripts/download_webcams.sh
+++ b/scripts/download_webcams.sh
@@ -1,5 +1,11 @@
-set -eo pipefail
+#!/bin/bash
 
-echo Download webcams
-echo TODO implement logic
-lftp --help
+set -eo pipefail
+set -x
+
+1>&2 echo 'Downloading webcam images'
+lftp -e "mirror -c --parallel=20 --verbose / /var/webcam; quit;" -u $IPL_WEBCAM_USER,$IPL_WEBCAM_PASSWORD $IPL_WEBCAM_SERVER
+# Delete all old webcam images
+find /var/webcam -mtime +$WEBCAM_KEEP_DAYS -type f -name '*.jpeg' -delete
+# Delete all empty directories
+find /var/webcam  -type d -empty -delete

--- a/scripts/download_webcams.sh
+++ b/scripts/download_webcams.sh
@@ -1,0 +1,5 @@
+set -eo pipefail
+
+echo Download webcams
+echo TODO implement logic
+lftp --help


### PR DESCRIPTION
This PR adds a `webcam_images` asset, which is materialized via a shell script wich transfers them via [lftp](https://en.wikipedia.org/wiki/Lftp).

Dagster will only execute one materialization in parallel, so this asset may perform an initially long running transfer followed by (currently minutely executed) transfer jobs.

In case of a non-zero exit code of the shell script, a `RuntimeException` will be thrown which fails the materialization.

`stdout` and `stderr` of the shell script are both captured and logged on the job's stderr.

NOTE: this PR is still WIP. I.e. the script needs to be implemented (or mounted from another place). In case further env variables are intended to be propagated to the script, these would need to be handled as well.