### PR TITLE
make worker configurable

### DIFF
--- a/pipeline/assets/webcams.py
+++ b/pipeline/assets/webcams.py
@@ -36,7 +36,15 @@ def webcam_images(context: AssetExecutionContext, pipes_subprocess_client: Pipes
     """
     Downloads webcam images via lftp.
     """
-    env = _env_vars_map(['IPL_WEBCAM_USER', 'IPL_WEBCAM_PASSWORD', 'IPL_WEBCAM_SERVER', 'WEBCAM_KEEP_DAYS'])
+    env = _env_vars_map(
+        [
+            'IPL_WEBCAM_USER',
+            'IPL_WEBCAM_PASSWORD',
+            'IPL_WEBCAM_SERVER',
+            'IPL_WEBCAM_KEEP_DAYS',
+            'IPL_WEBCAM_WORKER',
+        ],
+    )
     return pipes_subprocess_client.run(
         command=['bash', 'download_webcams.sh'], context=context, cwd=SCRIPT_DIR, env=env
     ).get_results()

--- a/scripts/download_webcams.sh
+++ b/scripts/download_webcams.sh
@@ -4,8 +4,8 @@ set -eo pipefail
 set -x
 
 1>&2 echo 'Downloading webcam images'
-lftp -e "mirror -c --parallel=20 --verbose / /var/webcam; quit;" -u $IPL_WEBCAM_USER,$IPL_WEBCAM_PASSWORD $IPL_WEBCAM_SERVER
+lftp -e "mirror -c --parallel=$IPL_WEBCAM_WORKER --verbose / /var/webcam; quit;" -u $IPL_WEBCAM_USER,$IPL_WEBCAM_PASSWORD $IPL_WEBCAM_SERVER
 # Delete all old webcam images
-find /var/webcam -mtime +$WEBCAM_KEEP_DAYS -type f -name '*.jpeg' -delete
+find /var/webcam -mtime +$IPL_WEBCAM_KEEP_DAYS -type f -name '*.jpeg' -delete
 # Delete all empty directories
 find /var/webcam  -type d -empty -delete


### PR DESCRIPTION
As we run into parallelization issues, workers can be set by env var now. Also fixes a naming issue with missing `IPL`.