### PR TITLE
chore: bump dagster version to 1.9.10

### DIFF
--- a/pipeline/assets/gtfs.py
+++ b/pipeline/assets/gtfs.py
@@ -7,8 +7,7 @@ import warnings
 
 import docker
 from dagster import (
-    AutoMaterializePolicy,
-    FreshnessPolicy,
+    AutomationCondition,
     graph_asset,
     op,
 )
@@ -75,8 +74,7 @@ def reload_pgbouncer_databases(import_op):
 
 @graph_asset(
     group_name='gtfs',
-    auto_materialize_policy=AutoMaterializePolicy.eager(),
-    freshness_policy=FreshnessPolicy(maximum_lag_minutes=60 * 24, cron_schedule='0 1 * * *'),
+    automation_condition=(AutomationCondition.on_cron('0 1 * * *') & ~AutomationCondition.in_progress() | AutomationCondition.eager()),
 )
 def gtfs():
     """

--- a/pipeline/assets/radvis.py
+++ b/pipeline/assets/radvis.py
@@ -2,10 +2,9 @@ import os
 import warnings
 
 from dagster import (
-    AutoMaterializePolicy,
+    AutomationCondition,
     EnvVar,
     ExperimentalWarning,
-    FreshnessPolicy,
     asset,
 )
 
@@ -27,8 +26,7 @@ RADVIS_OUT_FILENAME = 'radnetz_bw.gpkg'
 @asset(
     compute_kind='Geopackage',
     group_name='radvis',
-    freshness_policy=FreshnessPolicy(maximum_lag_minutes=60 * 24, cron_schedule='0 1 * * *'),
-    auto_materialize_policy=AutoMaterializePolicy.eager(),
+    automation_condition=(AutomationCondition.on_cron('0 1 * * *') & ~AutomationCondition.in_progress() | AutomationCondition.eager()),
 )
 def radnetz_bw_download() -> None:
     """
@@ -56,7 +54,7 @@ def radnetz_bw_download() -> None:
     non_argument_deps={'radnetz_bw_download'},
     compute_kind='PostGIS',
     group_name='radvis',
-    auto_materialize_policy=AutoMaterializePolicy.eager(),
+    automation_condition=AutomationCondition.eager(),
 )
 def radnetz_bw_postgis(ogr2ogr: Ogr2OgrResource) -> None:
     """

--- a/pipeline/assets/sharing.py
+++ b/pipeline/assets/sharing.py
@@ -2,11 +2,10 @@ import logging
 
 import pandas as pd
 from dagster import (
-    AutoMaterializePolicy,
+    AutomationCondition,
     DefaultScheduleStatus,
     DefaultSensorStatus,
     DynamicPartitionsDefinition,
-    FreshnessPolicy,
     RunRequest,
     ScheduleDefinition,
     SensorResult,
@@ -23,8 +22,7 @@ from pipeline.resources import LamassuResource
     io_manager_key='pg_gpd_io_manager',
     compute_kind='Lamassu',
     group_name='sharing',
-    freshness_policy=FreshnessPolicy(maximum_lag_minutes=60),
-    auto_materialize_policy=AutoMaterializePolicy.eager(),
+    automation_condition=(AutomationCondition.on_cron('0 * * * *') & ~AutomationCondition.in_progress() | AutomationCondition.eager()),
 )
 def sharing_stations(context, lamassu: LamassuResource) -> pd.DataFrame:
     """

--- a/pipeline/assets/traffic_incidents.py
+++ b/pipeline/assets/traffic_incidents.py
@@ -4,10 +4,9 @@ import warnings
 import geopandas as gpd
 import pandas as pd
 from dagster import (
-    AutoMaterializePolicy,
+    AutomationCondition,
     EnvVar,
     ExperimentalWarning,
-    FreshnessPolicy,
     asset,
 )
 
@@ -19,17 +18,13 @@ ROADWORKS_DATEX2_DOWNLOAD_URL = os.getenv('ROADWORKS_SVZBW_DATEX2_DOWNLOAD_URL',
 ROADWORKS_DATEXII_FIILENAME = 'roadworks_svzbw.datex2.xml'
 ROADWORKS_ASSET_KEY_PREFIX = ['traffic', 'roadworks']
 
-# In Dagster 1.6.6 AutoMaterializePolicy and shortcut for referencing upstream dependencies without fully qualified
-# path are experimental and might break, even between dot-releases. Nevertheless, we ignore the warning, but should
-# check when migrating to newer versions
 warnings.filterwarnings('ignore', category=ExperimentalWarning)
 
 
 @asset(
     compute_kind='DATEX2',
     group_name='traffic',
-    freshness_policy=FreshnessPolicy(maximum_lag_minutes=60 * 24, cron_schedule='0/5 * * * *'),
-    auto_materialize_policy=AutoMaterializePolicy.eager(),
+    automation_condition=(AutomationCondition.on_cron('0/5 * * * *') & ~AutomationCondition.in_progress() | AutomationCondition.eager()),
     key_prefix=ROADWORKS_ASSET_KEY_PREFIX,
 )
 def roadworks_svzbw_datex2() -> None:
@@ -43,11 +38,11 @@ def roadworks_svzbw_datex2() -> None:
 
 @asset(
     # TODO extend here if further roadwork sources are addedd
-    non_argument_deps={'roadworks_svzbw_datex2'},
+    deps={'roadworks_svzbw_datex2'},
     compute_kind='CIFS',
     group_name='traffic',
     io_manager_key='json_webasset_io_manager',
-    auto_materialize_policy=AutoMaterializePolicy.eager(),
+    automation_condition=AutomationCondition.eager(),
     key_prefix=ROADWORKS_ASSET_KEY_PREFIX,
 )
 def roadworks_cifs() -> dict:
@@ -60,11 +55,11 @@ def roadworks_cifs() -> dict:
 
 
 @asset(
-    non_argument_deps={'roadworks_svzbw_datex2'},
+    deps={'roadworks_svzbw_datex2'},
     compute_kind='GeoJSON',
     group_name='traffic',
     io_manager_key='json_webasset_io_manager',
-    auto_materialize_policy=AutoMaterializePolicy.eager(),
+    automation_condition=AutomationCondition.eager(),
     key_prefix=ROADWORKS_ASSET_KEY_PREFIX,
 )
 def roadworks_geojson() -> dict:
@@ -80,7 +75,7 @@ def roadworks_geojson() -> dict:
     compute_kind='PostGIS',
     group_name='traffic',
     io_manager_key='pg_gpd_io_manager',
-    auto_materialize_policy=AutoMaterializePolicy.eager(),
+    automation_condition=AutomationCondition.eager(),
 )
 def roadworks(roadworks_geojson) -> pd.DataFrame:
     """

--- a/pipeline/assets/webcams.py
+++ b/pipeline/assets/webcams.py
@@ -4,9 +4,8 @@ import warnings
 
 from dagster import (
     AssetExecutionContext,
-    AutoMaterializePolicy,
+    AutomationCondition,
     ExperimentalWarning,
-    FreshnessPolicy,
     PipesSubprocessClient,
     asset,
 )
@@ -28,8 +27,7 @@ def _env_vars_map(env_vars: list[str]) -> dict[str, str]:
 @asset(
     compute_kind='shell',
     group_name='webcams',
-    freshness_policy=FreshnessPolicy(maximum_lag_minutes=2, cron_schedule='* * * * *'),
-    auto_materialize_policy=AutoMaterializePolicy.eager(),
+    automation_condition=AutomationCondition.on_cron('* * * * *') & ~AutomationCondition.in_progress(),
 )
 # explicitly no typing '-> Sequence[PipesExecutionResult]' due to https://github.com/dagster-io/dagster/issues/25490
 def webcam_images(context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient):

--- a/requirements-dagster.txt
+++ b/requirements-dagster.txt
@@ -1,5 +1,5 @@
-dagster==1.8.12
-dagster-graphql==1.8.12
-dagster-webserver==1.8.12
-dagster-postgres==0.24.12
-dagster-docker==0.24.12
+dagster==1.9.10
+dagster-graphql==1.9.10
+dagster-webserver==1.9.10
+dagster-postgres==0.25.10
+dagster-docker==0.25.10

--- a/requirements-pipeline.txt
+++ b/requirements-pipeline.txt
@@ -1,6 +1,6 @@
-dagster==1.8.12
-dagster-postgres==0.24.12
-dagster-docker==0.24.12
+dagster==1.9.10
+dagster-postgres==0.25.10
+dagster-docker==0.25.10
 geopandas==0.14.3
 GeoAlchemy2==0.14.4
 # Because a specific version of the PyPi GDAL package depends on specific OS library versions, and because Ubuntu (LTS) currently only provides *older* versions of them, we ping GDAL to v3.6 here.


### PR DESCRIPTION
This PR updates dagster to version 1.9.10 and refactors deprecated `AutoMaterializationPolicy` and `FreshnessPolicy` to `AutomationCondition`

Note: While `AutomationCondition.eager()` mostly corresponds to `AutoMaterializationPolicy.eager()`, `FreshnessPolicy`'s change to `AutomationCondition.on_cron()` explicitly requires combining a check that no other execution is in progress.

See also https://github.com/dagster-io/dagster/discussions/23495