### PR TITLE
fix(roadworks): only push roadworks with geom_type LineString to postgis

### DIFF
--- a/pipeline/assets/traffic_incidents.py
+++ b/pipeline/assets/traffic_incidents.py
@@ -1,5 +1,7 @@
+import logging
 import os
 import warnings
+from typing import Any
 
 import geopandas as gpd
 import pandas as pd
@@ -23,6 +25,8 @@ ROADWORKS_ASSET_KEY_PREFIX = ['traffic', 'roadworks']
 # path are experimental and might break, even between dot-releases. Nevertheless, we ignore the warning, but should
 # check when migrating to newer versions
 warnings.filterwarnings('ignore', category=ExperimentalWarning)
+
+logger = logging.getLogger(__name__)
 
 
 @asset(
@@ -71,6 +75,8 @@ def roadworks_geojson() -> dict:
     """
     Transforms roadworks datasets into GeoJSON (mapping waze cifs to a commonly diggestable format)
     and publishes them.
+    Note: these may include roadworks with geometry type point. A point geometry type
+    is not recommended as downstream standards like e.g. CIFS can't handle them.
     """
     source = os.path.join(WEB_ROOT, *ROADWORKS_ASSET_KEY_PREFIX, ROADWORKS_DATEXII_FIILENAME)
     return DatexII2CifsTransformer('MobiData BW').transform(source, 'geojson')
@@ -82,8 +88,18 @@ def roadworks_geojson() -> dict:
     io_manager_key='pg_gpd_io_manager',
     auto_materialize_policy=AutoMaterializePolicy.eager(),
 )
-def roadworks(roadworks_geojson) -> pd.DataFrame:
+def roadworks(roadworks_geojson: dict[str, Any]) -> pd.DataFrame:
     """
     Imports the roadworks into PostGIS, from where they can be accessed e.g. via WMS/WFS.
+    Note: only roadworks with geom_type are imported!
     """
-    return gpd.GeoDataFrame.from_features(roadworks_geojson['features'], crs='epsg:4326')
+    roadworks_gdf = gpd.GeoDataFrame.from_features(roadworks_geojson['features'], crs='epsg:4326')
+    roadworks_not_linestrings = roadworks_gdf[roadworks_gdf.geom_type != 'LineString']
+    if len(roadworks_not_linestrings) > 0:
+        logger.warn(
+            f'''Ignored {len(roadworks_not_linestrings)} which had
+            geom_type!=LineString, e.g. with id="{roadworks_not_linestrings["id"].iloc[0]}'''
+        )
+        roadworks_only_linestrings_gdf = roadworks_gdf[roadworks_gdf.geom_type == 'LineString']
+        return roadworks_only_linestrings_gdf.set_index('id')
+    return roadworks_gdf.set_index('id')


### PR DESCRIPTION
This PR filters all roadworks which have a LineString geometry and explicitly sets the index to the id column. 
The latter will result in a primary key being created when #182 is merged.

Note: This PR should be merged before #182.