### PR TITLE
limit days at webcam download

### DIFF
--- a/scripts/download_webcams.sh
+++ b/scripts/download_webcams.sh
@@ -8,7 +8,7 @@ set -x
 find /var/webcam -mtime +$IPL_WEBCAM_KEEP_DAYS -type f -delete
 # Delete all empty directories
 find /var/webcam  -type d -empty -delete
-# Download all new files. Limit to now -(DOWNLOAD_MAX_DAYS - 1) days, otherwise we would delete and re-download data
+# Download all new files. Limit to now -(IPL_WEBCAM_KEEP_DAYS - 1) days, otherwise we would delete and re-download data
 # all the time.
 DOWNLOAD_MAX_DAYS=$((IPL_WEBCAM_KEEP_DAYS-1))
 lftp -e "mirror --newer-than=now-${DOWNLOAD_MAX_DAYS}days -c --parallel=$IPL_WEBCAM_WORKER --verbose / /var/webcam; quit;" -u $IPL_WEBCAM_USER,$IPL_WEBCAM_PASSWORD $IPL_WEBCAM_SERVER

--- a/scripts/download_webcams.sh
+++ b/scripts/download_webcams.sh
@@ -8,5 +8,7 @@ set -x
 find /var/webcam -mtime +$IPL_WEBCAM_KEEP_DAYS -type f -delete
 # Delete all empty directories
 find /var/webcam  -type d -empty -delete
-# Download all new files
-lftp -e "mirror -c --parallel=$IPL_WEBCAM_WORKER --verbose / /var/webcam; quit;" -u $IPL_WEBCAM_USER,$IPL_WEBCAM_PASSWORD $IPL_WEBCAM_SERVER
+# Download all new files. Limit to now -(DOWNLOAD_MAX_DAYS - 1) days, otherwise we would delete and re-download data
+# all the time.
+DOWNLOAD_MAX_DAYS=$((IPL_WEBCAM_KEEP_DAYS-1))
+lftp -e "mirror --newer-than=now-${DOWNLOAD_MAX_DAYS}days -c --parallel=$IPL_WEBCAM_WORKER --verbose / /var/webcam; quit;" -u $IPL_WEBCAM_USER,$IPL_WEBCAM_PASSWORD $IPL_WEBCAM_SERVER


### PR DESCRIPTION
Turns out, that the data source changed the amount of days they offer, which ended up into deleting and redownloading all files older then 7 days all the time, which again blocked necessary ports. This MR prevents this.