### PR TITLE
Chore: Upgrade to Dagster 1.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 The changelog lists most feature changes between each release. 
 
 ## Upcoming release
-* Fix: on startup, terminate runs still in started/starting state, as dagster doesn't terminate them cleanly on shutdown.
-* Fix: enable run monitoring to terminate jobs hanging on startup/cancellation (after 180s) or running for more than 6h
+- Fix: on startup, terminate runs still in started/starting state, as dagster doesn't terminate them cleanly on shutdown (https://github.com/mobidata-bw/ipl-dagster-pipeline/commit/81135abf8f80a4ba49f16fbcf24a6496a5bc48dc).
+- Fix: enable run monitoring to terminate jobs hanging on startup/cancellation (after 180s) or running for more than 6h (https://github.com/mobidata-bw/ipl-dagster-pipeline/commit/7defa4d7ec22f69595e2de2ad0ee3c49bd22dc90)
+    - ⚠️ NOTE: note this config needs to be replicated in case you use ipl-dagster-pipeline with an externally mounted dagster config.
+- Chore: [update to Dagster 1.10.2.](https://github.com/mobidata-bw/ipl-dagster-pipeline/pull/188)
+- Switch from deprecated `AutoMaterialization` and `FreshnessPolicy` to `AutomationCondition`. Assets will now be materialized on a cronlike schedule and eagerly on startup (in case they did not exist before).
 
 ## 2025-01-28
 - Fix: [create primary key if missing](https://github.com/mobidata-bw/ipl-dagster-pipeline/pull/182)

--- a/pipeline/assets/gtfs.py
+++ b/pipeline/assets/gtfs.py
@@ -7,8 +7,7 @@ import warnings
 
 import docker
 from dagster import (
-    AutoMaterializePolicy,
-    FreshnessPolicy,
+    AutomationCondition,
     graph_asset,
     op,
 )
@@ -75,8 +74,9 @@ def reload_pgbouncer_databases(import_op):
 
 @graph_asset(
     group_name='gtfs',
-    auto_materialize_policy=AutoMaterializePolicy.eager(),
-    freshness_policy=FreshnessPolicy(maximum_lag_minutes=60 * 24, cron_schedule='0 1 * * *'),
+    automation_condition=(
+        AutomationCondition.on_cron('0 1 * * *') & ~AutomationCondition.in_progress() | AutomationCondition.eager()
+    ),
 )
 def gtfs():
     """

--- a/pipeline/assets/radvis.py
+++ b/pipeline/assets/radvis.py
@@ -2,10 +2,9 @@ import os
 import warnings
 
 from dagster import (
-    AutoMaterializePolicy,
+    AutomationCondition,
     EnvVar,
     ExperimentalWarning,
-    FreshnessPolicy,
     asset,
 )
 
@@ -27,8 +26,9 @@ RADVIS_OUT_FILENAME = 'radnetz_bw.gpkg'
 @asset(
     compute_kind='Geopackage',
     group_name='radvis',
-    freshness_policy=FreshnessPolicy(maximum_lag_minutes=60 * 24, cron_schedule='0 1 * * *'),
-    auto_materialize_policy=AutoMaterializePolicy.eager(),
+    automation_condition=(
+        AutomationCondition.on_cron('0 1 * * *') & ~AutomationCondition.in_progress() | AutomationCondition.eager()
+    ),
 )
 def radnetz_bw_download() -> None:
     """
@@ -56,7 +56,7 @@ def radnetz_bw_download() -> None:
     non_argument_deps={'radnetz_bw_download'},
     compute_kind='PostGIS',
     group_name='radvis',
-    auto_materialize_policy=AutoMaterializePolicy.eager(),
+    automation_condition=AutomationCondition.eager(),
 )
 def radnetz_bw_postgis(ogr2ogr: Ogr2OgrResource) -> None:
     """

--- a/pipeline/assets/radvis.py
+++ b/pipeline/assets/radvis.py
@@ -4,14 +4,11 @@ import warnings
 from dagster import (
     AutomationCondition,
     EnvVar,
-    ExperimentalWarning,
     asset,
 )
 
 from pipeline.resources.gdal import Ogr2OgrResource
 from pipeline.util.urllib import download
-
-warnings.filterwarnings('ignore', category=ExperimentalWarning)
 
 WEB_ROOT = os.getenv('WWW_ROOT_DIR', './tmp/www')
 RADVIS_WFS_USER = os.getenv('RADVIS_WFS_USER')

--- a/pipeline/assets/sharing.py
+++ b/pipeline/assets/sharing.py
@@ -2,11 +2,10 @@ import logging
 
 import pandas as pd
 from dagster import (
-    AutoMaterializePolicy,
+    AutomationCondition,
     DefaultScheduleStatus,
     DefaultSensorStatus,
     DynamicPartitionsDefinition,
-    FreshnessPolicy,
     RunRequest,
     ScheduleDefinition,
     SensorResult,
@@ -23,8 +22,9 @@ from pipeline.resources import LamassuResource
     io_manager_key='pg_gpd_io_manager',
     compute_kind='Lamassu',
     group_name='sharing',
-    freshness_policy=FreshnessPolicy(maximum_lag_minutes=60),
-    auto_materialize_policy=AutoMaterializePolicy.eager(),
+    automation_condition=(
+        AutomationCondition.on_cron('0 * * * *') & ~AutomationCondition.in_progress() | AutomationCondition.eager()
+    ),
 )
 def sharing_stations(context, lamassu: LamassuResource) -> pd.DataFrame:
     """

--- a/pipeline/assets/traffic_incidents.py
+++ b/pipeline/assets/traffic_incidents.py
@@ -8,7 +8,6 @@ import pandas as pd
 from dagster import (
     AutomationCondition,
     EnvVar,
-    ExperimentalWarning,
     asset,
 )
 
@@ -19,8 +18,6 @@ WEB_ROOT = os.getenv('WWW_ROOT_DIR', './tmp/www')
 ROADWORKS_DATEX2_DOWNLOAD_URL = os.getenv('ROADWORKS_SVZBW_DATEX2_DOWNLOAD_URL', '')
 ROADWORKS_DATEXII_FIILENAME = 'roadworks_svzbw.datex2.xml'
 ROADWORKS_ASSET_KEY_PREFIX = ['traffic', 'roadworks']
-
-warnings.filterwarnings('ignore', category=ExperimentalWarning)
 
 logger = logging.getLogger(__name__)
 

--- a/pipeline/assets/webcams.py
+++ b/pipeline/assets/webcams.py
@@ -5,7 +5,6 @@ import warnings
 from dagster import (
     AssetExecutionContext,
     AutomationCondition,
-    ExperimentalWarning,
     PipesSubprocessClient,
     asset,
 )

--- a/pipeline/assets/webcams.py
+++ b/pipeline/assets/webcams.py
@@ -4,9 +4,8 @@ import warnings
 
 from dagster import (
     AssetExecutionContext,
-    AutoMaterializePolicy,
+    AutomationCondition,
     ExperimentalWarning,
-    FreshnessPolicy,
     PipesSubprocessClient,
     asset,
 )
@@ -28,8 +27,7 @@ def _env_vars_map(env_vars: list[str]) -> dict[str, str]:
 @asset(
     compute_kind='shell',
     group_name='webcams',
-    freshness_policy=FreshnessPolicy(maximum_lag_minutes=2, cron_schedule='* * * * *'),
-    auto_materialize_policy=AutoMaterializePolicy.eager(),
+    automation_condition=AutomationCondition.on_cron('* * * * *') & ~AutomationCondition.in_progress(),
 )
 # explicitly no typing '-> Sequence[PipesExecutionResult]' due to https://github.com/dagster-io/dagster/issues/25490
 def webcam_images(context: AssetExecutionContext, pipes_subprocess_client: PipesSubprocessClient):

--- a/requirements-dagster.txt
+++ b/requirements-dagster.txt
@@ -1,5 +1,5 @@
-dagster==1.9.10
-dagster-graphql==1.9.10
-dagster-webserver==1.9.10
-dagster-postgres==0.25.10
-dagster-docker==0.25.10
+dagster==1.10.2
+dagster-graphql==1.10.2
+dagster-webserver==1.10.2
+dagster-postgres==0.26.2
+dagster-docker==0.26.2

--- a/requirements-dagster.txt
+++ b/requirements-dagster.txt
@@ -1,5 +1,5 @@
-dagster==1.8.12
-dagster-graphql==1.8.12
-dagster-webserver==1.8.12
-dagster-postgres==0.24.12
-dagster-docker==0.24.12
+dagster==1.9.10
+dagster-graphql==1.9.10
+dagster-webserver==1.9.10
+dagster-postgres==0.25.10
+dagster-docker==0.25.10

--- a/requirements-pipeline.txt
+++ b/requirements-pipeline.txt
@@ -1,6 +1,6 @@
-dagster==1.8.12
-dagster-postgres==0.24.12
-dagster-docker==0.24.12
+dagster==1.9.10
+dagster-postgres==0.25.10
+dagster-docker==0.25.10
 geopandas==0.14.3
 GeoAlchemy2==0.14.4
 # Because a specific version of the PyPi GDAL package depends on specific OS library versions, and because Ubuntu (LTS) currently only provides *older* versions of them, we ping GDAL to v3.6 here.

--- a/requirements-pipeline.txt
+++ b/requirements-pipeline.txt
@@ -1,6 +1,6 @@
-dagster==1.9.10
-dagster-postgres==0.25.10
-dagster-docker==0.25.10
+dagster==1.10.2
+dagster-postgres==0.26.2
+dagster-docker==0.26.2
 geopandas==0.14.3
 GeoAlchemy2==0.14.4
 # Because a specific version of the PyPi GDAL package depends on specific OS library versions, and because Ubuntu (LTS) currently only provides *older* versions of them, we ping GDAL to v3.6 here.


### PR DESCRIPTION
This PR
* upgrades to Dagster 1.10.2
* migrates deprecated `AutoMaterialization` and `FreshnessPolicy` to `AutomationConditions`