### PR TITLE
fix: patch DagsterGraphQLClient to support forced run termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 The changelog lists most feature changes between each release. 
 
-## Upcoming release
-- Fix: on startup, terminate runs still in started/starting state, as dagster doesn't terminate them cleanly on shutdown (https://github.com/mobidata-bw/ipl-dagster-pipeline/commit/81135abf8f80a4ba49f16fbcf24a6496a5bc48dc).
+## 2025-03-12
+- Fix: on startup, (force) terminate runs still in started/starting state, as dagster doesn't terminate them cleanly on shutdown (https://github.com/mobidata-bw/ipl-dagster-pipeline/commit/81135abf8f80a4ba49f16fbcf24a6496a5bc48dc).
 - Fix: enable run monitoring to terminate jobs hanging on startup/cancellation (after 180s) or running for more than 6h (https://github.com/mobidata-bw/ipl-dagster-pipeline/commit/7defa4d7ec22f69595e2de2ad0ee3c49bd22dc90)
     - ⚠️ NOTE: note this config needs to be replicated in case you use ipl-dagster-pipeline with an externally mounted dagster config.
 - Chore: [update to Dagster 1.10.2.](https://github.com/mobidata-bw/ipl-dagster-pipeline/pull/188)

--- a/scripts/terminate_starting_and_started_runs.py
+++ b/scripts/terminate_starting_and_started_runs.py
@@ -1,7 +1,12 @@
 import logging
 import socket
 import time
+from typing import Any
 
+# Dagster Patch ---------------------------------------------------
+import dagster._check as check
+
+# / Dagster Patch ---------------------------------------------------
 from dagster import DagsterRunStatus
 from dagster_graphql import DagsterGraphQLClient, DagsterGraphQLClientError
 from requests.exceptions import ConnectionError
@@ -32,6 +37,79 @@ query RunsQuery ($filter: RunsFilter) {
 }
 '''
 
+# Dagster Patch  (see also https://github.com/dagster-io/dagster/pull/28339)  -----
+
+TERMINATE_RUNS_JOB_MUTATION = '''
+mutation GraphQLClientTerminateRuns($runIds: [String!]! $terminatePolicy: TerminateRunPolicy) {
+  terminateRuns(runIds: $runIds, terminatePolicy: $terminatePolicy) {
+    __typename
+    ... on TerminateRunsResult {
+      terminateRunResults {
+        __typename
+        ... on TerminateRunSuccess {
+          run  {
+            runId
+          }
+        }
+        ... on TerminateRunFailure {
+          message
+        }
+        ... on RunNotFoundError {
+          runId
+          message
+        }
+        ... on UnauthorizedError {
+          message
+        }
+        ... on PythonError {
+          message
+          stack
+        }
+      }
+    }
+  }
+}
+'''
+
+
+def terminate_runs(self, run_ids: list[str], force: bool = False):
+    """Terminates a list of pipeline runs. This method it is useful when you would like to stop a list of pipeline runs
+    based on a external event.
+
+    Args:
+        run_ids (List[str]): The list run ids of the pipeline runs to terminate
+    """
+    check.list_param(run_ids, 'run_ids', of_type=str)
+
+    res_data: dict[str, dict[str, Any]] = self._execute(
+        TERMINATE_RUNS_JOB_MUTATION,
+        {'runIds': run_ids, 'terminatePolicy': 'MARK_AS_CANCELED_IMMEDIATELY' if force else 'SAFE_TERMINATE'},
+    )
+
+    query_result: dict[str, Any] = res_data['terminateRuns']
+    run_query_result: list[dict[str, Any]] = query_result['terminateRunResults']
+
+    errors = []
+    for run_result in run_query_result:
+        if run_result['__typename'] == 'TerminateRunSuccess':
+            continue
+        if run_result['__typename'] == 'RunNotFoundError':
+            errors.append(('RunNotFoundError', run_result['message']))
+        else:
+            errors.append((run_result['__typename'], run_result['message']))
+
+    if errors:
+        if len(errors) < len(run_ids):
+            raise DagsterGraphQLClientError('TerminateRunsError', f'Some runs could not be terminated: {errors}')
+        if len(errors) == len(run_ids):
+            raise DagsterGraphQLClientError('TerminateRunsError', f'All run terminations failed: {errors}')
+
+
+# Patch DagsterGraphQLClient.terminate_runs to support force option
+DagsterGraphQLClient.terminate_runs = terminate_runs  # type: ignore[method-assign]
+
+# / End of dagster patch --------------------------
+
 
 def get_run_ids_of_runs(status: list[str], timeout: int = 20) -> list[str]:
     variables = {'filter': {'statuses': status}}
@@ -54,6 +132,7 @@ run_ids = get_run_ids_of_runs(['STARTED', 'STARTING'])
 
 if len(run_ids) > 0:
     logger.info(f'Terminating runs {run_ids}')
-    client.terminate_runs(run_ids)
+
+    client.terminate_runs(run_ids, True)  # type: ignore[call-arg]
 else:
     logger.info('No run in state STARTED or STARTING')


### PR DESCRIPTION
This PR patches `DagsterGraphQLClient.terminate_runs` to support an additional `force: bool` argument.
This is a backport of https://github.com/dagster-io/dagster/pull/28339
 