### PR TITLE
fix: provide unique ids for multi-period incidents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The changelog lists most feature changes between each release.
 ## [unreleased]
 - 
 
+## 2026-05-05
+- Fix: Provide unique IDs for multi-period roadworks.
+- ⚠️ BEMaS roadwork IDs, which were uuids copied straight from BEMaS situation records, now have a three digit counter appended (e.g. ".001") to guarantee that they are still unique after situation records with multiple validtyPeriods are split in multiple incidents.
+
 ## 2026-05-04
 
 - Fix: Split BEMaS short term roadworks on subsequent days into multiple roadworks (#269)

--- a/pipeline/transformer/cifs.py
+++ b/pipeline/transformer/cifs.py
@@ -364,8 +364,15 @@ class DatexII2CifsTransformer:
                 closure['location'] = location
 
                 periods = self._get_periods(situationRecord)
+                period_counter = 0
                 for period in periods:
                     new_closure = closure.copy()
+                    # Append couter to create unique IDs though roadworks have been split
+                    # Note: we increase counter before checking if period should be skipped
+                    # which will result in (somewhat more) stable IDs if roadworks periods 
+                    # are unmodified 
+                    period_counter += 1
+                    new_closure['id']=f'{new_closure['id']}.{period_counter:03d}'
                     (starttime, endtime) = period
                     if self.current_time.astimezone() > datetime.fromisoformat(endtime):
                         # ignore periods in the past

--- a/tests/transformer/situation_multi_valid_consecutive_periods.xml
+++ b/tests/transformer/situation_multi_valid_consecutive_periods.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<d2LogicalModel modelBaseVersion="2" xmlns="http://datex2.eu/schema/2/2_0">
+    <exchange>
+        <supplierIdentification>
+            <country>de</country>
+            <nationalIdentifier>test</nationalIdentifier>
+        </supplierIdentification>
+    </exchange>
+    <payloadPublication xsi:type="SituationPublication" lang="DE" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <publicationTime>2026-04-20T10:02:45.684+02:00</publicationTime>
+        <publicationCreator>
+            <country>de</country>
+            <nationalIdentifier>test</nationalIdentifier>
+        </publicationCreator>
+        <situation id="2454613" version="876">
+            <overallSeverity>low</overallSeverity>
+            <situationVersionTime>2026-04-10T11:11:25.030+02:00</situationVersionTime>
+            <headerInformation>
+                <confidentiality>noRestriction</confidentiality>
+                <informationStatus>test</informationStatus>
+            </headerInformation>
+            <situationRecord xsi:type="ConstructionWorks" id="2454613-37594876-37594877-37594882" version="876">
+                <situationRecordCreationTime>2025-03-29T06:14:53.755+01:00</situationRecordCreationTime>
+                <situationRecordVersionTime>2025-03-29T06:15:25.457+01:00</situationRecordVersionTime>
+                <probabilityOfOccurrence>certain</probabilityOfOccurrence>
+                <validity>
+                    <validityStatus>definedByValidityTimeSpec</validityStatus>
+                    <validityTimeSpecification>
+                        <overallStartTime>2025-04-14T07:00:00.000+02:00</overallStartTime>
+                        <overallEndTime>2025-04-15T20:00:00.000+02:00</overallEndTime>
+                        <validPeriod>
+                            <startOfPeriod>2025-04-14T20:00:00.000+02:00</startOfPeriod>
+                            <endOfPeriod>2025-04-15T00:00:00.000+02:00</endOfPeriod>
+                        </validPeriod>
+                        <validPeriod>
+                            <startOfPeriod>2025-04-15T00:00:00.000+02:00</startOfPeriod>
+                            <endOfPeriod>2025-04-15T07:00:00.000+02:00</endOfPeriod>
+                        </validPeriod>
+                        <validPeriod>
+                            <startOfPeriod>2025-04-15T20:00:00.000+02:00</startOfPeriod>
+                            <endOfPeriod>2025-04-16T00:00:00.000+02:00</endOfPeriod>
+                        </validPeriod>
+                        <validPeriod>
+                            <startOfPeriod>2025-04-16T00:00:00.000+02:00</startOfPeriod>
+                            <endOfPeriod>2025-04-16T07:00:00.000+02:00</endOfPeriod>
+                        </validPeriod>
+                    </validityTimeSpecification>
+                </validity>
+                <impact>
+                    <capacityRemaining>1470.0</capacityRemaining>
+                    <residualRoadWidth>3.25</residualRoadWidth>
+                    <impactExtension>
+                        <impactExtended>
+                            <laneStatusCoded>e2i</laneStatusCoded>
+                            <laneRestriction>
+                                <lane>allLanesCompleteCarriageway</lane>
+                            </laneRestriction>
+                        </impactExtended>
+                    </impactExtension>
+                </impact>
+                <generalPublicComment>
+                    <comment>
+                        <values>
+                            <value lang="DE">A81 Bauwerksarbeiten Rückbau LSW</value>
+                        </values>
+                    </comment>
+                    <commentExtension>
+                        <commentExtended>
+                            <commentType2>roadworksName</commentType2>
+                        </commentExtended>
+                    </commentExtension>
+                </generalPublicComment>
+                <generalPublicComment>
+                    <comment>
+                        <values>
+                            <value lang="DE">Bauwerksarbeiten</value>
+                        </values>
+                    </comment>
+                    <commentExtension>
+                        <commentExtended>
+                            <commentType2>roadworksType</commentType2>
+                        </commentExtended>
+                    </commentExtension>
+                </generalPublicComment>
+                <generalPublicComment>
+                    <comment>
+                        <values>
+                            <value lang="DE"></value>
+                        </values>
+                    </comment>
+                </generalPublicComment>
+                <groupOfLocations xsi:type="Linear">
+                    <locationForDisplay>
+                        <latitude>48.694458</latitude>
+                        <longitude>9.012799</longitude>
+                    </locationForDisplay>
+                    <linearExtension>
+                        <linearExtended>
+                            <gmlLineString>
+                                <srsName>WGS84 EPSG 4326</srsName>
+                                <posList>48.694460 9.012799 48.694391 9.012520 48.694310 9.012200 48.694270 9.012010</posList>
+                                <roadInformation/>
+                            </gmlLineString>
+                        </linearExtended>
+                    </linearExtension>
+                </groupOfLocations>
+                <situationRecordExtension>
+                    <situationRecordExtended>
+                        <extendedLaneStatusCoded>iue2i</extendedLaneStatusCoded>
+                    </situationRecordExtended>
+                </situationRecordExtension>
+                <actionPlanIdentifier>B10</actionPlanIdentifier>
+                <operatorActionStatus>requested</operatorActionStatus>
+                <roadworksDuration>shortTerm</roadworksDuration>
+                <mobility>
+                    <mobilityType>stationary</mobilityType>
+                </mobility>
+                <constructionWorkType>constructionWork</constructionWorkType>
+            </situationRecord>
+        </situation>
+    </payloadPublication>
+</d2LogicalModel>

--- a/tests/transformer/situation_multi_valid_periods.xml
+++ b/tests/transformer/situation_multi_valid_periods.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<d2LogicalModel modelBaseVersion="2" xmlns="http://datex2.eu/schema/2/2_0">
+    <exchange>
+        <supplierIdentification>
+            <country>de</country>
+            <nationalIdentifier>test</nationalIdentifier>
+        </supplierIdentification>
+    </exchange>
+    <payloadPublication xsi:type="SituationPublication" lang="DE" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <publicationTime>2026-04-20T10:02:45.684+02:00</publicationTime>
+        <publicationCreator>
+            <country>de</country>
+            <nationalIdentifier>test</nationalIdentifier>
+        </publicationCreator>
+        <situation id="2454613" version="876">
+            <overallSeverity>low</overallSeverity>
+            <situationVersionTime>2026-04-10T11:11:25.030+02:00</situationVersionTime>
+            <headerInformation>
+                <confidentiality>noRestriction</confidentiality>
+                <informationStatus>test</informationStatus>
+            </headerInformation>
+            <situationRecord xsi:type="ConstructionWorks" id="2454613-37594876-37594877-37594882" version="876">
+                <situationRecordCreationTime>2025-03-29T06:14:53.755+01:00</situationRecordCreationTime>
+                <situationRecordVersionTime>2025-03-29T06:15:25.457+01:00</situationRecordVersionTime>
+                <probabilityOfOccurrence>certain</probabilityOfOccurrence>
+                <validity>
+                    <validityStatus>definedByValidityTimeSpec</validityStatus>
+                    <validityTimeSpecification>
+                        <overallStartTime>2025-04-14T07:00:00.000+02:00</overallStartTime>
+                        <overallEndTime>2025-04-15T20:00:00.000+02:00</overallEndTime>
+                        <validPeriod>
+                            <startOfPeriod>2025-04-14T07:00:00.000+02:00</startOfPeriod>
+                            <endOfPeriod>2025-04-14T20:00:00.000+02:00</endOfPeriod>
+                        </validPeriod>
+                        <validPeriod>
+                            <startOfPeriod>2025-04-15T07:00:00.000+02:00</startOfPeriod>
+                            <endOfPeriod>2025-04-15T20:00:00.000+02:00</endOfPeriod>
+                        </validPeriod>
+                    </validityTimeSpecification>
+                </validity>
+                <impact>
+                    <capacityRemaining>1470.0</capacityRemaining>
+                    <residualRoadWidth>3.25</residualRoadWidth>
+                    <impactExtension>
+                        <impactExtended>
+                            <laneStatusCoded>e2i</laneStatusCoded>
+                            <laneRestriction>
+                                <lane>allLanesCompleteCarriageway</lane>
+                            </laneRestriction>
+                        </impactExtended>
+                    </impactExtension>
+                </impact>
+                <generalPublicComment>
+                    <comment>
+                        <values>
+                            <value lang="DE">A81 Bauwerksarbeiten Rückbau LSW</value>
+                        </values>
+                    </comment>
+                    <commentExtension>
+                        <commentExtended>
+                            <commentType2>roadworksName</commentType2>
+                        </commentExtended>
+                    </commentExtension>
+                </generalPublicComment>
+                <generalPublicComment>
+                    <comment>
+                        <values>
+                            <value lang="DE">Bauwerksarbeiten</value>
+                        </values>
+                    </comment>
+                    <commentExtension>
+                        <commentExtended>
+                            <commentType2>roadworksType</commentType2>
+                        </commentExtended>
+                    </commentExtension>
+                </generalPublicComment>
+                <generalPublicComment>
+                    <comment>
+                        <values>
+                            <value lang="DE"></value>
+                        </values>
+                    </comment>
+                </generalPublicComment>
+                <groupOfLocations xsi:type="Linear">
+                    <locationForDisplay>
+                        <latitude>48.694458</latitude>
+                        <longitude>9.012799</longitude>
+                    </locationForDisplay>
+                    <linearExtension>
+                        <linearExtended>
+                            <gmlLineString>
+                                <srsName>WGS84 EPSG 4326</srsName>
+                                <posList>48.694460 9.012799 48.694391 9.012520 48.694310 9.012200 48.694270 9.012010</posList>
+                                <roadInformation/>
+                            </gmlLineString>
+                        </linearExtended>
+                    </linearExtension>
+                </groupOfLocations>
+                <situationRecordExtension>
+                    <situationRecordExtended>
+                        <extendedLaneStatusCoded>iue2i</extendedLaneStatusCoded>
+                    </situationRecordExtended>
+                </situationRecordExtension>
+                <actionPlanIdentifier>B10</actionPlanIdentifier>
+                <operatorActionStatus>requested</operatorActionStatus>
+                <roadworksDuration>shortTerm</roadworksDuration>
+                <mobility>
+                    <mobilityType>stationary</mobilityType>
+                </mobility>
+                <constructionWorkType>constructionWork</constructionWorkType>
+            </situationRecord>
+        </situation>
+    </payloadPublication>
+</d2LogicalModel>

--- a/tests/transformer/test_cifs.py
+++ b/tests/transformer/test_cifs.py
@@ -9,7 +9,7 @@ from pipeline.transformer.cifs import DatexII2CifsTransformer
 def test_situation_1487640():
     """
     This tests asserts that for a complex situationRecord describing a
-    roadwork with multiple indipendent situations, some of them in the past,
+    roadwork with multiple independent situations, some of them in the past,
     only the currently active situtation is extracted with it's corresponding properties.
     """
     t = DatexII2CifsTransformer('Test', current_time=datetime.strptime('2024-01-01', '%Y-%m-%d'))
@@ -33,18 +33,63 @@ def test_situation_2959413():
     t = DatexII2CifsTransformer('Test', current_time=datetime.strptime('2024-01-01', '%Y-%m-%d'))
     cifs = t.transform('./tests/transformer/situation_2959413-4272241-4272242-4272245.xml')
     assert 'incidents' in cifs
-    incident = list(filter(lambda incident: incident['id'] == '2959413-4272241-4272242-4272245', cifs['incidents']))[0]
+    incident = list(filter(lambda incident: incident['id'] == '2959413-4272241-4272242-4272245.001', cifs['incidents']))[0]
 
     assert incident['type'] == 'CONSTRUCTION'
     assert incident['location']['street'] == 'L409 B294/L409 Krähenhart-B462/L409 Klosterreichenbach'
     assert incident['description'] == 'L409 Lkw-Verbot'
 
 
+def test_situation_multi_valid_periods():
+    """
+    This tests asserts that for a situationRecord with multiple separate validPeriods, 
+    multiple incidents are created.
+    """
+    expected_feature_properties = {
+        'reference': 'Test',
+        'description': 'A81 Bauwerksarbeiten Rückbau LSW',
+        'street': 'Gemeindestraße',
+        'direction': 'BOTH_DIRECTIONS',
+        'starttime': '2025-04-15T07:00:00.000+02:00',
+        'endtime': '2025-04-15T20:00:00.000+02:00',
+        'id': '2454613-37594876-37594877-37594882.002',
+        'type': 'CONSTRUCTION',
+        'subtype': '',
+    }
+
+    t = DatexII2CifsTransformer('Test', current_time=datetime.strptime('2024-01-01', '%Y-%m-%d'))
+    geojson = t.transform('./tests/transformer/situation_multi_valid_periods.xml', format='geojson')
+    
+    assert len(geojson.get('features')) == 2
+    assert geojson['features'][1]['properties'] == expected_feature_properties
+    # Assert IDs are unique
+    ids = set([incident['properties']['id'] for incident in geojson['features']])
+    assert len(geojson['features'])== len(ids)
+
+
+def test_situation_multi_valid_consecutive_periods():
+    """
+    This tests asserts that for a situationRecord with multiple separate but consecutive
+    validPeriods, these are merged.
+    """
+    t = DatexII2CifsTransformer('Test', current_time=datetime.strptime('2024-01-01', '%Y-%m-%d'))
+    cifs = t.transform('./tests/transformer/situation_multi_valid_consecutive_periods.xml')
+    assert 'incidents' in cifs
+    assert len(cifs['incidents']) == 2
+    assert cifs['incidents'][0]['endtime'] == '2025-04-15T07:00:00.000+02:00'
+    assert cifs['incidents'][1]['endtime'] == '2025-04-16T07:00:00.000+02:00'
+    
 @pytest.mark.parametrize(
     'test_laneStatusCoded,expected',
     [('x2x', True), ('u1x', False), ('sluu2xxro', False), ('uo2xx', True), ('uu2uoo', True)],
 )
 def test_eval(test_laneStatusCoded, expected):
+    """
+    Assert that DatexII2CifsTransformer deduces correctly from laneStatusCoded, 
+    if opposite direction is concerned.
+    Opposite direction is concerned if all lanes on left carriageway (=left of lane separator code 1 or 2)
+    are unrestricted (u) and no opposite lane is shifted to the right carriageway.
+    """
     t = DatexII2CifsTransformer('Test')
 
     assert t._is_opposite_direction_concerned(test_laneStatusCoded) == expected


### PR DESCRIPTION
This PR adds a counter to BEMaS roadwork IDs, which were uuids copied straight from BEMaS situation records, now have a three digit counter appended (e.g. ".001") to guarantee that they are still unique after situation records with multiple validityPeriods are split in multiple incidents.
