### PR TITLE
fix: raise exception if download fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The changelog lists most feature changes between each release.
 
 ## [unreleased]
--
+- Fix: in case of a download error, let the task fail instead of storing the exception response as download result
 
 ## 2026-05-18
 - ⚠️ Addition: download roadworks/incidents datasets from Mobilithek and republish them (traffic/roadworks/roadworks_adb_short_term.datex2.xml, traffic/roadworks/roadworks_adb_long_term.datex2.xml, traffic/incidents/incidents_lmsbw.datex2.xml ). This requires new ENV VARs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 The changelog lists most feature changes between each release.
 
 ## [unreleased]
+-
+
+## 2026-06-29
 - Fix: in case of a download error, let the task fail instead of storing the exception response as download result
 
 ## 2026-05-18

--- a/pipeline/util/urllib.py
+++ b/pipeline/util/urllib.py
@@ -73,6 +73,9 @@ def download(
             # File not modified since last download
             return False
 
+        # In case of error (e.g. status code 404 / 500), we raise an exception
+        response.raise_for_status()
+
         with tmp_filename.open('wb') as file:
             for chunk in response.iter_content(chunk_size=1024 * 1024):
                 if chunk:


### PR DESCRIPTION
This PR raises an exception, if a file download results in an unsuccessfull http status code.
